### PR TITLE
7.4.6. Also support for scripts to run on install

### DIFF
--- a/PowerShell.plg
+++ b/PowerShell.plg
@@ -2,8 +2,8 @@
 <!DOCTYPE PLUGIN [
 <!ENTITY name      "PowerShell">
 <!ENTITY author    "x-radeon">
-<!ENTITY version   "7.4.5">
-<!ENTITY sha256    "C23509CC4D08C62B9FF6EA26F579EE4C50F978AA34269334A85EDA2FEC36F45B">
+<!ENTITY version   "7.4.6">
+<!ENTITY sha256    "6F6015203C47806C5CC444C19D8ED019695E610FBD948154264BF9CA8E157561">
 <!ENTITY launch    "Settings/&name;">
 <!ENTITY plugdir   "/usr/local/emhttp/plugins/&name;">
 <!ENTITY plugin    "/boot/config/plugins/&name;">
@@ -13,6 +13,9 @@
 <PLUGIN name="&name;" author="&author;" version="&version;" launch="&launch;" pluginURL="&pluginURL;" min="6.9.2" support="https://forums.unraid.net/topic/135932-plugin-powershell/">
 
 <CHANGES>
+###2024-12-04
+- PowerShell Version 7.4.6 (https://github.com/PowerShell/PowerShell/releases/tag/v7.4.6)
+
 ###2024-10-20
 - PowerShell Version 7.4.5 (https://github.com/PowerShell/PowerShell/releases/tag/v7.4.5)
 
@@ -34,34 +37,63 @@
 
 <FILE Run="/bin/bash">
 <INLINE>
+# 
+# Set up variables
+# 
 checksumverified=false
+pluginDir=&plugin;
+pwshVersion=&version;
+thisSHA256=&sha256;
+
+set -e
+
+# 
+# Set up variables
+# 
+pwshDownloadFilename="powershell-${pwshVersion}-linux-x64.tar.gz"
+pwshDownloadPath="${pluginDir}/${pwshDownloadFilename}"
+pwshDownloadBase="https://github.com/PowerShell/PowerShell/releases/download/v${pwshVersion}"
+pwshDownloadURL="${pwshDownloadBase}/${pwshDownloadFilename}"
+pwshDownloadOutputSHA256="${thisSHA256}  ${pwshDownloadPath}"
+pwshInstallDir="/opt/microsoft/powershell/${pwshVersion}"
+pwshExecutable="${pwshInstallDir}/pwsh"
+pwshExecutableBin="/usr/bin/pwsh"
+
 echo "Removing Old Install"
-rm -rf /usr/bin/pwsh /opt/microsoft/powershell
-find /boot/config/plugins/PowerShell -type f -regex '.*powershell-.*-linux-x64.tar.gz' ! -iname powershell-&version;-linux-x64.tar.gz -delete
-echo "Creating Directory"
-mkdir -p /opt/microsoft/powershell/7
-if [ ! -d /boot/config/plugins/PowerShell ]
-then
-  mkdir -p /boot/config/plugins/&name;
-fi
-if echo "&sha256;  /boot/config/plugins/PowerShell/powershell-&version;-linux-x64.tar.gz" | sha256sum -c
-then
+rm -rf "$pwshExecutableBin" $(dirname "${pwshInstallDir}")
+find "${pluginDir}" -type f -regex '.*powershell-.*-linux-x64.tar.gz' ! -iname $pwshDownloadFilename -delete
+
+echo "Creating Directories (if they don't exist)"
+mkdir -p "${pwshInstallDir}" "${pluginDir}"
+
+if echo "$pwshDownloadOutputSHA256" | sha256sum -c; then
   echo "Using already downloaded file"
   checksumverified=true
 else
-  echo "Need to download PowerShell. Downloading Source https://github.com/PowerShell/PowerShell/releases/download/v&version;/powershell-&version;-linux-x64.tar.gz"
-  curl -L -o &plugin;/powershell-&version;-linux-x64.tar.gz https://github.com/PowerShell/PowerShell/releases/download/v&version;/powershell-&version;-linux-x64.tar.gz
-  if echo "&sha256;  /boot/config/plugins/PowerShell/powershell-&version;-linux-x64.tar.gz" | sha256sum -c ; then checksumverified=true ; fi
+  echo "Need to download PowerShell. Downloading Source $pwshDownloadURL"
+  curl -L -o $pwshDownloadPath $pwshDownloadURL
+  if echo "$pwshDownloadOutputSHA256" | sha256sum -c ; then checksumverified=true ; fi
 fi
+
 if [ $checksumverified == true ] ; then
   echo "Untar files"
-  tar zxf &plugin;/powershell-&version;-linux-x64.tar.gz -C /opt/microsoft/powershell/7
+  tar zxf "${pwshDownloadPath}" -C $pwshInstallDir
   echo "Set execute permissions"
-  chmod +x /opt/microsoft/powershell/7/pwsh
+  chmod +x $pwshExecutable
   echo "Create the symbolic link that points to pwsh"
-  ln -s /opt/microsoft/powershell/7/pwsh /usr/bin/pwsh
-  echo "Finished"
+  ln -s "${pwshExecutable}" "${pwshExecutableBin}"
+  echo "Finished Install"
+  
+  #
+  # Find any powershell scripts that have been added in here and run them
+  #
+  pwshFiles=$(find "${pluginDir}" -type f -name '*.ps1' -print | sort)
+  for pwshFile in $pwshFiles; do
+    echo "Running $pwshFile"
+    pwsh "$pwshFile"
+  done
 else
+  echo "${pwshDownloadPath}"
   echo "Failed to verify checksum!!!"
 fi
 </INLINE>

--- a/README.md
+++ b/README.md
@@ -1,10 +1,11 @@
 # unraid-powershell
 This is an Unraid plugin for Microsoft PowerShell (https://github.com/PowerShell/PowerShell).
 
-
 The install is performed, basically, as described [here](https://learn.microsoft.com/en-us/powershell/scripting/install/install-other-linux?view=powershell-7.4#installation-using-a-binary-archive-file).
 
 It probably needs some improvement.
+
+## Powershell version
 
 Version will be lock step with the PowerShell stable version
 
@@ -17,6 +18,19 @@ pwsh /boot/config/plugins/myscripts/script.ps1
 ## Steps To Increment Plugin Version
 1. View PowerShell versions at https://github.com/PowerShell/powershell/releases
 2. Change version (line 5) to new version
-3. Update SHA256 hash (line 6) to new hash
-  - Use hash for powershell-X.X.X-linux-x64.tar.gz
+3. Update SHA256 hash (line 6) to new hash (use hash for powershell-X.X.X-linux-x64.tar.gz)
 4. Add info in the <CHANGES> section (line 15) simliar to previous changes
+
+
+## Automatically Run scripts on startup/install
+
+If you place any ps1 files into the plugin folder (`/boot/config/plugins/PowerShell`), then they will be executed once the plugin install has been done. 
+
+See [here](./startupScriptsExample.md) for an example
+
+__Considerations__
+
+* The filenames are sorted alphabetically, so if you want to run multiple files, make sure you name them appropriately.
+* The scripts are going to be running without any visibility, so you need to ensure that they aren't going to be prompting you for any reason
+* *Make sure you only install modules from sources that you trust!*
+* Don't just blindly copy/paste scripts from the internet without understanding what they're doing

--- a/startupScriptsExample.md
+++ b/startupScriptsExample.md
@@ -1,0 +1,82 @@
+[← README](./README.md)
+
+# Retrieve unraid keyfile from an Azure Keyvault
+
+For example, this set of files (all in `/boot/config/plugins/PowerShell/`) will 
+* install some modules for Azure Keyvault manipulation
+* retrieve the value for /root/keyfile from the KV and write it
+
+## `00.trust.ps1`
+
+Set the PSGallery repo to be Trusted so that we don't get prompted when installing modules from there
+
+``` powershell
+Set-PSRepository -Name "PSGallery" -InstallationPolicy Trusted
+```
+
+## `01.installModule.ps1`
+
+Install required modules 
+
+``` powershell
+Install-Module -Name Az.Accounts -AllowClobber -Force
+Install-Module -Name Az.KeyVault -AllowClobber -Force
+```
+
+## `02.getKeyfile.ps1`
+
+Get the secret value from an Azure keyvault. 
+
+The thinking behind this is,
+* If the keyfile is saved on the USB drive (as is the default practice), then if someone knocks-off my whole server then they can decrypt my drives and access any of my data once they plug it back in again
+* But not if the keyfile isn't actually stored on the server at all
+* On boot, connect to Az Keyvault, retrive the keyfile value and write it to /root/keyfile
+* Before anyone gets excited and tells me that I shouldn't have the client secret etc. hard-coded in here because it makes the whole keyvault exercise pointless, i'm actually (marginally) smarter than that.
+  * the Keyvault has a firewall set up on it in Azure such that it can only be accessed from certain locations; so essentially, if they are not on my LAN then they won't be able to access the KV to get the keyfile so they can't decrypt the drives
+
+Issues/Limitations with this method
+ * If then internet is down, then I cannot retrieve the key - so can't unlock the drives. That being said, the internet only needs to be up while the script is running (as once the keyfile is in /root/ then all is good in the world)
+ * Keyvault firewall rules need to be maintained - if you've got it set up to only allow access for a given (public) IP, if your ISP changes your IP then you'll need to nip into Azure to change the config
+ * Service Principal Secret value - they expire, so you need to keep on top of that.
+
+``` powershell
+#!/usr/bin/pwsh
+
+$ErrorActionPreference = 'Stop'
+
+$KeyVaultName = 'MY-KEYVAULT-NAME'
+$SecretName = 'unraid' # name of the secret in the KV
+$TenantId = 'a1b2c3d4-e5f6-7890-ab12-cd34ef567890'
+$ApplicationId = '12345678-90ab-cdef-1234-567890abcdef' # Service Principal ID
+$clientSecret = 'P@ssw0rd!23$%^&*()_+AbCdEfGhIjKlMnOpQrStUvWxYz1234567890' | ConvertTo-SecureString -AsPlainText -Force
+$Credential = New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList $ApplicationId, $clientSecret
+
+# Connect to Azure account
+Connect-AzAccount -ServicePrincipal -Tenant $TenantId -Credential $Credential *> $null
+
+# Retrieve a secret from the Key Vault
+# Get the secret with error handling
+try {
+    $secret = Get-AzKeyVaultSecret -VaultName $KeyVaultName -Name $SecretName
+} catch {
+    Write-Host "Error retrieving the secret: $_"
+    Disconnect-AzAccount *> $null
+    exit 1
+}
+
+# Check if the secret was retrieved successfully
+if ($null -ne $secret -and $null -ne $secret.Id -and $null -ne $secret.Name) {
+    Write-Host "Secret retrieved successfully."
+    $keyfile="/root/keyfile"
+    Write-Host "Writing secret to $keyfile"
+    Set-Content -Path $keyfile -Value (ConvertFrom-SecureString -SecureString $secret.SecretValue -AsPlainText) -NoNewline
+    chmod 600 $keyfile
+} else {
+    Write-Host "Failed to retrieve the secret."
+}
+
+Disconnect-AzAccount *> $null
+```
+
+
+[← README](./README.md)


### PR DESCRIPTION
# PWSH Upgrade
Upgraded to pwsh 7.4.6

# Startup Scripts

Make the .plg file execute any *.ps1 files which are in the plugin folder - this allows for installation of modules etc. on boot of the unraid server without having to resort to the User Scripts plugin. Also an additional md file showing/explaining an example

# bash readability

Also made the bash componentry of the plugin easier to read (IMHO of course!) by setting variables for things which are constants and are used more than once.